### PR TITLE
Add grunt tasks for watching the server & client files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,12 @@
 module.exports = function(grunt) {
+    grunt.loadNpmTasks("grunt-concurrent");
     grunt.loadNpmTasks("grunt-contrib-jshint");
+    grunt.loadNpmTasks("grunt-contrib-watch");
     grunt.loadNpmTasks("grunt-jscs");
 
     var files = ["Gruntfile.js", "server.js", "server/**/*.js", "test/**/*.js", "client/**/*.js"];
+
+    var serveProc = null;
 
     grunt.initConfig({
         jshint: {
@@ -17,10 +21,62 @@ module.exports = function(grunt) {
                 config: ".jscsrc",
                 fix: true
             }
+        },
+        watch: {
+            serve: {
+                files: ["server.js", "server/**/*.js", "test/**/*.js"],
+                tasks: ["check", "restartServer"],
+                options: {
+                    atBegin: true,
+                    spawn: false,
+                },
+            },
+            client: {
+                files: ["client/**/*.js", "test/**/*.js"],
+                tasks: ["check"],
+                options: {
+                    atBegin: true,
+                    spawn: false,
+                },
+            }
+        },
+        concurrent: {
+            watch: {
+                tasks: ["watch:serve", "watch:client"],
+                options: {
+                    logConcurrentOutput: true
+                }
+            }
+        },
+    });
+
+    grunt.event.on("watch", function(action, filepath, target) {
+        grunt.config("jshint.all", filepath);
+        grunt.config("jscs.all", filepath);
+    });
+
+    grunt.registerTask("startServer", "Task that starts a server attached to the Grunt process.", function () {
+        var cmd = process.execPath;
+        process.env.DEV_MODE = true;
+        serveProc = grunt.util.spawn({
+            cmd: cmd,
+            args: ["server.js"]
+        }, function(err) {
+            return err;
+        });
+        serveProc.stdout.pipe(process.stdout);
+        serveProc.stderr.pipe(process.stderr);
+    });
+    grunt.registerTask("killServer", "Task that stops the server if it is running.", function () {
+        if (serveProc) {
+            serveProc.kill();
         }
     });
 
+    grunt.registerTask("runApp", ["concurrent:watch"]);
+    grunt.registerTask("restartServer", ["killServer", "startServer"]);
     grunt.registerTask("check", ["jshint", "jscs"]);
     grunt.registerTask("test", ["check"]);
     grunt.registerTask("default", "test");
 };
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "homepage": "https://github.com/stevenhillcox/Bristol-Grads-2016#readme",
   "devDependencies": {
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-concurrent": "^2.3.1",
     "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-jscs": "^3.0.1"
   },
   "dependencies": {

--- a/server/server.js
+++ b/server/server.js
@@ -7,3 +7,4 @@ module.exports = function(port) {
 
     return app.listen(port);
 };
+


### PR DESCRIPTION
@Geor23 @stevenhillcox @BRHoward 

Just a couple grunt tasks that'll automatically lint the server/client files when they're changed, and also restart the server if server files are changed (and can also be combined with a bundler and test files later).
