### PR TITLE
unauthorised account handling

### DIFF
--- a/server/oauth-google.js
+++ b/server/oauth-google.js
@@ -1,7 +1,8 @@
 module.exports = function(oauth2Client, verifier, fs) {
 
     var oAuthUri = oauth2Client.generateAuthUrl({
-        scope: "profile"
+        scope: "profile",
+        prompt: "select_account"
     });
 
     function authorise(req, callback) {

--- a/server/server.js
+++ b/server/server.js
@@ -22,8 +22,14 @@ module.exports = function(port, client, googleAuthoriser) {
                 res.sendStatus(302);
             }
             else {
-                console.log(err);
-                res.sendStatus(400);
+                if (err.message === "Unauthorised user") {
+                    console.log("not you pal");
+                    res.header("Location", "/dash.html");
+                    res.sendStatus(302);
+                } else {
+                    console.log(err);
+                    res.sendStatus(400);
+                }
             }
         });
     });

--- a/spec/server/admin.spec.js
+++ b/spec/server/admin.spec.js
@@ -186,6 +186,18 @@ describe("Admin", function () {
             });
         });
 
+        it("GET /oauth responds with a redirect to /dash if authentication succeeds but user is not authorised", function (done) {
+            sinon.stub(authoriser, "authorise", function(req, authCallback) {
+                authCallback(new Error("Unauthorised user"), null);
+            });
+
+            request(baseUrl + "/oauth", function(error, response, body) {
+                expect(response.statusCode).toEqual(200);
+                expect(response.request.uri.path).toEqual("/dash.html");
+                done();
+            });
+        });
+
         it("GET /api/oauth/uri responds with url", function (done) {
             request(baseUrl + "/api/oauth/uri", function(error, response, body) {
                 expect(response.statusCode).toEqual(200);


### PR DESCRIPTION
Logging in with a google account that isn't authorised to access the admin dash boots you back to the admin dash login page. This means you can be logged in to google with as many accounts as you like without breaking the app login.
