### PR TITLE
Use tweet ID strings to allow for full-precision id handling

### DIFF
--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -2,15 +2,24 @@ module.exports = function(client) {
     var tweetStore = [];
     var hashtags = ["#bristech", "#bristech2016"];
 
+    // Compares two strings that represent numbers of greater size than can be handled as `number` types without loss
+    // of precision, and returns true if the first is numerically greater than the second
+    function idStrComp(a, b) {
+        if (Number(a) === Number(b)) {
+            return a > b;
+        }
+        return Number(a) > Number(b);
+    }
+
     var apiResources = {
         "search/tweets": {
-            since_id: 0,
+            since_id: "0",
             basePath: "search",
             requestsRemaining: 0,
             resetTime: 0,
             addData: function(tweets) {
                 this.since_id = tweets.statuses.reduce(function(since, currTweet) {
-                    return since > currTweet.id ? since : currTweet.id;
+                    return idStrComp(since, currTweet.id_str) ? since : currTweet.id_str;
                 }, this.since_id);
                 tweetStore = tweetStore.concat(tweets.statuses.sort(function(statusA, statusB) {
                     return statusA.id - statusB.id;
@@ -18,13 +27,13 @@ module.exports = function(client) {
             }
         },
         "statuses/user_timeline": {
-            since_id: 0,
+            since_id: "0",
             basePath: "statuses",
             requestsRemaining: 0,
             resetTime: 0,
             addData: function(tweets) {
                 this.since_id = tweets.reduce(function(since, currTweet) {
-                    return since > currTweet.id ? since : currTweet.id;
+                    return idStrComp(since, currTweet.id_str) ? since : currTweet.id_str;
                 }, this.since_id);
                 tweetStore = tweetStore.concat(tweets.sort(function(statusA, statusB) {
                     return statusA.id - statusB.id;
@@ -85,7 +94,7 @@ module.exports = function(client) {
 
     function getTweetResource(resource, query) {
         var last_id = apiResources[resource].since_id;
-        if (last_id > 0) {
+        if (last_id !== "0") {
             query.since_id = last_id;
         }
         client.get(resource, query, function(error, data, response) {

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -9,9 +9,11 @@ var getTweets;
 
 var testTimeline = [{
     id: 1,
+    id_str: "1",
     text: "Test tweet 1",
 }, {
     id: 2,
+    id_str: "2",
     text: "Test tweet 2",
 }];
 
@@ -97,7 +99,7 @@ describe("tweetSearch", function () {
         it("uses the id of the most recently acquired tweet as the since_id for subsequent queries", function() {
             getLatestCallback(resource)(null, defaultData, testResponseOk);
             jasmine.clock().tick(5000);
-            expect(getQueries(resource)[1].since_id).toEqual(2);
+            expect(getQueries(resource)[1].since_id).toEqual("2");
         });
 
         it("serves acquired tweets through the getTweets function", function() {
@@ -165,6 +167,7 @@ describe("tweetSearch", function () {
             tweetSearcher.deleteTweet(1);
             expect(tweetSearcher.getTweetStore()).toEqual([{
                 id: 2,
+                id_str: "2",
                 text: "Test tweet 2",
             }]);
         });


### PR DESCRIPTION
Solves the "duplicate tweets" problem.
