### PR TITLE
Tweet bundle events

### DIFF
--- a/client/templates/adminTweetWall.html
+++ b/client/templates/adminTweetWall.html
@@ -25,7 +25,7 @@
                         <div ng-bind-html="tweet.text"></div>
                         <div>{{tweet.created_at | date : medium}}</div>
                     </div>
-                    <md-button class="md-secondary md-icon-button" ng-click="deleteTweet(tweet.id)">
+                    <md-button class="md-secondary md-icon-button" ng-click="deleteTweet(tweet.id_str)">
                         <md-icon><i class="material-icons">clear</i></md-icon>
                     </md-button>
                     <md-divider></md-divider>

--- a/server.js
+++ b/server.js
@@ -16,10 +16,11 @@ var twitterClient = new Twitter({
     access_token_key: process.env.TWITTER_ACCESS_TOKEN_KEY,
     access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET
 });
+var tweetSearcher = require("./server/tweetSearch")(twitterClient);
 
 var oauth2Client = new google.auth.OAuth2(oauthClientId, oauthSecret, REDIRECT_URL);
 var googleAuthoriser = oAuthGoogle(oauth2Client, verifier, fs);
 
-server(port, twitterClient, googleAuthoriser);
+server(port, tweetSearcher, googleAuthoriser);
 
 console.log("Server running on port " + port);

--- a/server/server.js
+++ b/server/server.js
@@ -2,9 +2,8 @@ var express = require("express");
 var cookieParser = require("cookie-parser");
 var bodyParser = require("body-parser");
 
-module.exports = function(port, client, googleAuthoriser) {
+module.exports = function(port, tweetSearcher, googleAuthoriser) {
     var app = express();
-    var tweetSearcher = require("./tweetSearch")(client);
 
     var adminSessions = {};
 

--- a/server/server.js
+++ b/server/server.js
@@ -68,8 +68,12 @@ module.exports = function(port, tweetSearcher, googleAuthoriser) {
     });
 
     app.post("/admin/tweets/delete", function(req, res) {
-        tweetSearcher.deleteTweet(req.body.id);
-        res.sendStatus(200);
+        try {
+            tweetSearcher.deleteTweet(req.body.id);
+            res.sendStatus(200);
+        } catch (err) {
+            res.sendStatus(404);
+        }
     });
 
     app.get("/api/tweets", function(req, res) {

--- a/server/server.js
+++ b/server/server.js
@@ -78,7 +78,7 @@ module.exports = function(port, client, googleAuthoriser) {
     });
 
     function getTweets() {
-        return tweetSearcher.getTweetStore();
+        return tweetSearcher.getTweetData().tweets;
     }
 
     return app.listen(port);

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -51,6 +51,20 @@ module.exports = function(client) {
     var searchUpdater;
     var userUpdater;
 
+    var hashtagUpdateFn = tweetResourceGetter("search/tweets", {q: hashtags.join(" OR ")});
+    var timelineUpdateFn = tweetResourceGetter("statuses/user_timeline", {screen_name: "bristech"});
+
+    getApplicationRateLimits(function() {
+        resourceUpdate("search/tweets", hashtagUpdateFn, searchUpdater);
+        resourceUpdate("statuses/user_timeline", timelineUpdateFn, userUpdater);
+    });
+
+    return {
+        getTweetStore: getTweetStore,
+        deleteTweet: deleteTweet,
+        loadTweets: loadTweets,
+    };
+
     function resourceUpdate(apiResource, updateFn, timer) {
         if (apiResources[apiResource].requestsRemaining > 0) {
             updateFn();
@@ -64,20 +78,6 @@ module.exports = function(client) {
             }, apiResources[apiResource].resetTime - new Date().getTime());
         }
     }
-
-    var hashtagUpdateFn = tweetResourceGetter("search/tweets", {q: hashtags.join(" OR ")});
-    var timelineUpdateFn = tweetResourceGetter("statuses/user_timeline", {screen_name: "bristech"});
-
-    getApplicationRateLimits(function() {
-        resourceUpdate("search/tweets", hashtagUpdateFn, searchUpdater);
-        resourceUpdate("statuses/user_timeline", timelineUpdateFn, userUpdater);
-    });
-
-    return {
-        getTweetStore: getTweetStore,
-        deleteTweet: deleteTweet,
-        setTweetStore: setTweetStore
-    };
 
     function deleteTweet(id) {
         var res = tweetStore.filter(function(tweet) {

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -86,8 +86,8 @@ module.exports = function(client) {
         tweetStore = res;
     }
 
-    function loadTweets(tweets) {
-        addTweetItem(tweets, "test");
+    function loadTweets(tweets, type) {
+        addTweetItem(tweets, type);
     }
 
     function getTweetStore() {

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -94,10 +94,6 @@ module.exports = function(client) {
         return tweetStore;
     }
 
-    function setTweetStore(value) {
-        tweetStore = value;
-    }
-
     function getTweetsSince(since) {
         var update = tweetUpdates.find(function(update) {
             return update.since >= since;

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -14,6 +14,17 @@ module.exports = function(client) {
     }
 
     function deleteTweet(tweetId) {
+        // Not really a necessary check, and can be taken out if the performance hit becomes too large, but acts as a
+        // way of preventing deletes of tweets that haven't appeared yet.
+        // This is important, as such deletes would result in tweets disappearing from queries as the "since" time is
+        // moved back - which would be an unintuitive and confusing behaviour.
+        var deletedTweet = tweetStore.find(function(tweet) {
+            return tweet.id_str === tweetId;
+        });
+        if (!deletedTweet) {
+            throw new Error("Cannot delete tweet that the server does not have.");
+        }
+        // The actual point of the function
         tweetUpdates.push({
             type: "tweet_status",
             since: new Date(),
@@ -72,7 +83,6 @@ module.exports = function(client) {
     });
 
     return {
-        getTweetStore: getTweetStore,
         getTweetData: getTweetData,
         deleteTweet: deleteTweet,
         loadTweets: loadTweets,

--- a/spec/server/admin.spec.js
+++ b/spec/server/admin.spec.js
@@ -6,7 +6,7 @@ var sinon = require("sinon");
 var testPort = 1234;
 var baseUrl = "http://localhost:" + testPort;
 
-var client;
+var tweetSearcher;
 var authoriser;
 var testServer;
 var cookieJar;
@@ -19,8 +19,10 @@ describe("Admin", function () {
     beforeEach(function () {
         cookieJar = request.jar();
 
-        client = {
-            get: sinon.stub()
+        tweetSearcher = {
+            getTweetData: jasmine.createSpy("getTweetData"),
+            deleteTweet: jasmine.createSpy("deleteTweet"),
+            loadTweets: jasmine.createSpy("loadTweets"),
         };
 
         authoriser = {
@@ -28,7 +30,7 @@ describe("Admin", function () {
             oAuthUri: oAuthUri
         };
 
-        testServer = server(testPort, client, authoriser);
+        testServer = server(testPort, tweetSearcher, authoriser);
 
     });
 

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -104,16 +104,16 @@ describe("tweetSearch", function () {
 
         it("serves acquired tweets through the getTweets function", function() {
             getLatestCallback(resource)(null, defaultData, testResponseOk);
-            var tweets = tweetSearcher.getTweetStore();
-            expect(tweets).toEqual(testTimeline);
+            var tweetData = tweetSearcher.getTweetData();
+            expect(tweetData.tweets).toEqual(testTimeline);
         });
 
         it("prints an error and adds no tweets if the twitter client returns an error", function() {
             spyOn(console, "log");
             getLatestCallback(resource)("Failed", null, testResponseOk);
             expect(console.log).toHaveBeenCalledWith("Failed");
-            var tweets = tweetSearcher.getTweetStore();
-            expect(tweets.length).toEqual(0);
+            var tweetData = tweetSearcher.getTweetData();
+            expect(tweetData.tweets.length).toEqual(0);
         });
 
         it("does not attempt to query the twitter api until the reset time if the rate limit has been reached",
@@ -158,13 +158,11 @@ describe("tweetSearch", function () {
         beforeEach(function() {
             tweetSearcher.loadTweets(testTimeline, "test");
         });
-        it("getTweetStore returns the tweet store", function() {
-            expect(tweetSearcher.getTweetStore()).toEqual(testTimeline);
-        });
 
-        it("deletes one tweet from the tweet store whose id is passed as parameter", function() {
-            tweetSearcher.deleteTweet(1);
-            expect(tweetSearcher.getTweetStore()).toEqual([{
+        it("does not serve tweets that have been deleted via deleteTweet", function() {
+            expect(tweetSearcher.getTweetData().tweets).toEqual(testTimeline);
+            tweetSearcher.deleteTweet("1");
+            expect(tweetSearcher.getTweetData().tweets).toEqual([{
                 id: 2,
                 id_str: "2",
                 text: "Test tweet 2",

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -156,8 +156,7 @@ describe("tweetSearch", function () {
 
     describe("deleteTweet", function() {
         beforeEach(function() {
-            tweetSearcher.setTweetStore(testTimeline);
-
+            tweetSearcher.loadTweets(testTimeline);
         });
         it("getTweetStore returns the tweet store", function() {
             expect(tweetSearcher.getTweetStore()).toEqual(testTimeline);

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -156,7 +156,7 @@ describe("tweetSearch", function () {
 
     describe("deleteTweet", function() {
         beforeEach(function() {
-            tweetSearcher.loadTweets(testTimeline);
+            tweetSearcher.loadTweets(testTimeline, "test");
         });
         it("getTweetStore returns the tweet store", function() {
             expect(tweetSearcher.getTweetStore()).toEqual(testTimeline);


### PR DESCRIPTION
Changes the internal tweet-handling of the tweet searcher module to be event-based, with stored timestamps. Doesn't change anything functionally by itself, but makes live client updates (including deletes, and with low bandwidth+latency) trivial; also paves a good deal of the way to prioritized tweets, and anything else involving applying a status to a tweet.
