### PR TITLE
Prevent duplicate tweet collection

### DIFF
--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -3,6 +3,26 @@ module.exports = function(client) {
     var tweetUpdates = [];
     var hashtags = ["#bristech", "#bristech2016"];
     var mentions = ["@bristech"];
+    var officialUsers = ["bristech"];
+
+    function tweetType(tweet) {
+        if (officialUsers.indexOf(tweet.user.name) !== -1) {
+            return "official";
+        }
+        var foundHashtag = hashtags.reduce(function(found, hashtag) {
+            return found || tweet.text.indexOf(hashtag) !== -1;
+        }, false);
+        if (foundHashtag) {
+            return "tagged";
+        }
+        var foundMention = mentions.reduce(function(found, mention) {
+            return found || tweet.text.indexOf(mention) !== -1;
+        }, false);
+        if (foundMention) {
+            return "tagged";
+        }
+        return "";
+    }
 
     function addTweetItem(tweets, tag) {
         if (tweets.length === 0) {
@@ -58,7 +78,10 @@ module.exports = function(client) {
                 this.since_id = tweets.statuses.reduce(function(since, currTweet) {
                     return idStrComp(since, currTweet.id_str) ? since : currTweet.id_str;
                 }, this.since_id);
-                addTweetItem(tweets.statuses, "tagged");
+                var taggedTweets = tweets.statuses.filter(function(tweet) {
+                    return tweetType(tweet) === "tagged";
+                });
+                addTweetItem(taggedTweets, "tagged");
             }
         },
         "statuses/user_timeline": {
@@ -70,7 +93,10 @@ module.exports = function(client) {
                 this.since_id = tweets.reduce(function(since, currTweet) {
                     return idStrComp(since, currTweet.id_str) ? since : currTweet.id_str;
                 }, this.since_id);
-                addTweetItem(tweets, "official");
+                var officialTweets = tweets.filter(function(tweet) {
+                    return tweetType(tweet) === "official";
+                });
+                addTweetItem(officialTweets, "official");
             }
         },
     };

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -58,6 +58,17 @@ var testTweets = {
     }],
 };
 
+var testTweetsMixed = {
+    statuses: testTweets.statuses.concat({
+        id: 10,
+        id_str: "10",
+        text: "Test official tweet #bristech",
+        user: {
+            name: "bristech",
+        },
+    }),
+};
+
 var testResponseOk = {
     headers: {
         "x-rate-limit-remaining": 180,
@@ -179,6 +190,12 @@ describe("tweetSearch", function () {
         });
 
         resourceQueryTests("search/tweets", testTweets, testTweets.statuses);
+
+        it("does not save tweets that belong to a higher-priority tweet category", function () {
+            getLatestCallback("search/tweets")(null, testTweetsMixed, testResponseOk);
+            var tweetData = tweetSearcher.getTweetData();
+            expect(tweetData.tweets).toEqual(testTweets.statuses);
+        });
     });
 
     describe("getTweetsFrom", function() {

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -11,10 +11,16 @@ var testTimeline = [{
     id: 1,
     id_str: "1",
     text: "Test tweet 1",
+    user: {
+        name: "bristech",
+    },
 }, {
     id: 2,
     id_str: "2",
     text: "Test tweet 2",
+    user: {
+        name: "bristech",
+    },
 }];
 
 var testTimeline2 = [{
@@ -28,7 +34,28 @@ var testTimeline2 = [{
 }];
 
 var testTweets = {
-    statuses: testTimeline,
+    statuses: [{
+        id: 1,
+        id_str: "1",
+        text: "Test tweet 1 #bristech",
+        user: {
+            name: "randomjoe",
+        },
+    }, {
+        id: 2,
+        id_str: "2",
+        text: "Test tweet 2 #bristech",
+        user: {
+            name: "randomjoe",
+        },
+    }, {
+        id: 5,
+        id_str: "5",
+        text: "Test tweet 3 @bristech",
+        user: {
+            name: "randomjoe",
+        },
+    }],
 };
 
 var testResponseOk = {
@@ -98,7 +125,7 @@ describe("tweetSearch", function () {
         jasmine.clock().uninstall();
     });
 
-    function resourceQueryTests(resource, defaultData) {
+    function resourceQueryTests(resource, defaultData, defaultOutput) {
         it("performs an additional query after a 5 second delay", function() {
             jasmine.clock().tick(4999);
             expect(getQueries(resource).length).toEqual(1);
@@ -109,13 +136,13 @@ describe("tweetSearch", function () {
         it("uses the id of the most recently acquired tweet as the since_id for subsequent queries", function() {
             getLatestCallback(resource)(null, defaultData, testResponseOk);
             jasmine.clock().tick(5000);
-            expect(getQueries(resource)[1].since_id).toEqual("2");
+            expect(getQueries(resource)[1].since_id).toEqual(defaultOutput[defaultOutput.length - 1].id_str);
         });
 
         it("serves acquired tweets through the getTweets function", function() {
             getLatestCallback(resource)(null, defaultData, testResponseOk);
             var tweetData = tweetSearcher.getTweetData();
-            expect(tweetData.tweets).toEqual(testTimeline);
+            expect(tweetData.tweets).toEqual(defaultOutput);
         });
 
         it("prints an error and adds no tweets if the twitter client returns an error", function() {
@@ -151,7 +178,7 @@ describe("tweetSearch", function () {
             expect(queries[0]).toEqual({q: "#bristech OR #bristech2016 OR @bristech"});
         });
 
-        resourceQueryTests("search/tweets", testTweets);
+        resourceQueryTests("search/tweets", testTweets, testTweets.statuses);
     });
 
     describe("getTweetsFrom", function() {
@@ -161,7 +188,7 @@ describe("tweetSearch", function () {
             expect(queries[0]).toEqual({screen_name: "bristech"});
         });
 
-        resourceQueryTests("statuses/user_timeline", testTimeline);
+        resourceQueryTests("statuses/user_timeline", testTimeline, testTimeline);
     });
 
     describe("getTweetData", function() {
@@ -252,6 +279,9 @@ describe("tweetSearch", function () {
                 id: 2,
                 id_str: "2",
                 text: "Test tweet 2",
+                user: {
+                    name: "bristech",
+                },
             }]);
         });
     });


### PR DESCRIPTION
Adds a function that gets a tweet's "type" (official or tagged atm) and uses that to make sure each tweet will only get stored for a single type of query (any official tweets are stored as official, regardless of whether the tweet contains tags or not).
