### PR TITLE
Admin modify speakers

### DIFF
--- a/client/angular/controllers/AdminController.js
+++ b/client/angular/controllers/AdminController.js
@@ -26,6 +26,7 @@
 
         $scope.sortByDate = tweetTextManipulationService.sortByDate;
         $scope.addSpeaker = addSpeaker;
+        $scope.removeSpeaker = removeSpeaker;
 
         $scope.setMotd = function () {
             adminDashDataService.setMotd($scope.ctrl.motd).then(function (result) {
@@ -90,6 +91,14 @@
         function addSpeaker() {
             adminDashDataService.addSpeaker($scope.ctrl.speaker).then(function (result) {
                 $scope.ctrl.speaker = "";
+                return adminDashDataService.getSpeakers();
+            }).then(function (speakers) {
+                $scope.speakers = speakers;
+            });
+        }
+
+        function removeSpeaker(speaker) {
+            adminDashDataService.removeSpeaker(speaker).then(function (result) {
                 return adminDashDataService.getSpeakers();
             }).then(function (speakers) {
                 $scope.speakers = speakers;

--- a/client/angular/services/adminDashDataService.js
+++ b/client/angular/services/adminDashDataService.js
@@ -13,7 +13,9 @@
             setMotd: setMotd,
             getTweets: getTweets,
             getMotd: getMotd,
-            deleteTweet: deleteTweet
+            deleteTweet: deleteTweet,
+            addSpeaker: addSpeaker,
+            getSpeakers: getSpeakers,
         };
 
         function authenticate() {
@@ -61,6 +63,22 @@
         function deleteTweet(id) {
             return $http.post("/admin/tweets/delete", {
                 id: id,
+            }, {
+                headers: {
+                    "Content-type": "application/json"
+                }
+            });
+        }
+
+        function getSpeakers() {
+            return $http.get("/api/speakers").then(function (result) {
+                return result.data;
+            });
+        }
+
+        function addSpeaker(name) {
+            return $http.post("/admin/speakers/add", {
+                name: name,
             }, {
                 headers: {
                     "Content-type": "application/json"

--- a/client/angular/services/adminDashDataService.js
+++ b/client/angular/services/adminDashDataService.js
@@ -16,6 +16,7 @@
             deleteTweet: deleteTweet,
             addSpeaker: addSpeaker,
             getSpeakers: getSpeakers,
+            removeSpeaker: removeSpeaker,
         };
 
         function authenticate() {
@@ -77,7 +78,17 @@
         }
 
         function addSpeaker(name) {
-            return $http.post("/admin/speakers/add", {
+            return $http.post("/admin/speakers", {
+                name: name,
+            }, {
+                headers: {
+                    "Content-type": "application/json"
+                }
+            });
+        }
+
+        function removeSpeaker(name) {
+            return $http.delete("/admin/speakers", {
                 name: name,
             }, {
                 headers: {

--- a/client/templates/adminMenu.html
+++ b/client/templates/adminMenu.html
@@ -12,7 +12,10 @@
         </button>
         <md-menu-content class="admin-menu-item">
             <md-menu-item ng-repeat="speaker in speakers" class="md-indent admin-menu-item">
-                {{speaker}}
+                <md-button ng-click="removeSpeaker(speaker)" style="width: 0px" class="admin-menu-button md-no-focus">
+                    <i class="material-icons" style="margin-bottom: 15px; width: 0px">clear</i>
+                </md-button>
+                <span style="margin-top: 3px">{{speaker}}</span>
             </md-menu-item>
             <md-menu-divider></md-menu-divider>
             <md-menu-item class="md-indent admin-menu-item">

--- a/client/templates/adminMenu.html
+++ b/client/templates/adminMenu.html
@@ -10,7 +10,19 @@
         <button ng-click="$mdOpenMenu()" class="admin-menu-button">
         SPEAKERS
         </button>
-        <md-menu-content>
+        <md-menu-content class="admin-menu-item">
+            <md-menu-item ng-repeat="speaker in speakers" class="md-indent admin-menu-item">
+                {{speaker}}
+            </md-menu-item>
+            <md-menu-divider></md-menu-divider>
+            <md-menu-item class="md-indent admin-menu-item">
+                <i class="material-icons" style="margin-bottom: 45px; width: 40px">add</i>
+                <form ng-submit="addSpeaker()">
+                    <md-input-container>
+                        <input ng-model="ctrl.speaker" placeholder="New speaker" autocomplete="off"></input>
+                    </md-input-container>
+                </form>
+            </md-menu-item>
         </md-menu-content>
     </md-menu>
     <md-menu>

--- a/client/templates/adminMenu.html
+++ b/client/templates/adminMenu.html
@@ -11,13 +11,6 @@
         SPEAKERS
         </button>
         <md-menu-content class="admin-menu-item">
-            <md-menu-item ng-repeat="speaker in speakers" class="md-indent admin-menu-item">
-                <md-button ng-click="removeSpeaker(speaker)" style="width: 0px" class="admin-menu-button md-no-focus">
-                    <i class="material-icons" style="margin-bottom: 15px; width: 0px">clear</i>
-                </md-button>
-                <span style="margin-top: 3px">{{speaker}}</span>
-            </md-menu-item>
-            <md-menu-divider></md-menu-divider>
             <md-menu-item class="md-indent admin-menu-item">
                 <i class="material-icons" style="margin-bottom: 45px; width: 40px">add</i>
                 <form ng-submit="addSpeaker()">
@@ -25,6 +18,13 @@
                         <input ng-model="ctrl.speaker" placeholder="New speaker" autocomplete="off"></input>
                     </md-input-container>
                 </form>
+            </md-menu-item>
+            <md-menu-divider></md-menu-divider>
+            <md-menu-item ng-repeat="speaker in speakers" class="md-indent admin-menu-item">
+                <md-button ng-click="removeSpeaker(speaker)" style="width: 0px" class="admin-menu-button md-no-focus">
+                    <i class="material-icons" style="margin-bottom: 15px; width: 0px">clear</i>
+                </md-button>
+                <span style="margin-top: 3px">{{speaker}}</span>
             </md-menu-item>
         </md-menu-content>
     </md-menu>

--- a/spec/client/controllers/AdminController.spec.js
+++ b/spec/client/controllers/AdminController.spec.js
@@ -17,7 +17,9 @@ describe("AdminController", function () {
 
     var testSpeakers = ["Walt", "Jesse", "Hank", "Mike", "Saul"];
     var testNewSpeaker = "Gus";
-    var testNewSpeakers = ["Walt", "Jesse", "Hank", "Mike", "Saul", "Gus"];
+    var testAddedSpeakers = ["Walt", "Jesse", "Hank", "Mike", "Saul", "Gus"];
+    var testRemoveSpeaker = "Mike";
+    var testRemovedSpeakers = ["Walt", "Jesse", "Hank", "Saul"];
 
     var testTweets = [{
         text: "Test tweet 1 #hello @bristech",
@@ -87,6 +89,7 @@ describe("AdminController", function () {
             "deleteTweet",
             "getSpeakers",
             "addSpeaker",
+            "removeSpeaker",
             "logOut",
         ]);
         tweetTextManipulationService = jasmine.createSpyObj("tweetTextManipulationService", [
@@ -244,7 +247,7 @@ describe("AdminController", function () {
             deferredSpeakerResponse.resolve();
             adminDashDataService.addSpeaker.and.returnValue(deferredSpeakerResponse.promise);
             adminDashDataService.getSpeakers.and.returnValues(deferredGetSpeakersResponse.promise);
-            deferredGetSpeakersResponse.resolve(testNewSpeakers);
+            deferredGetSpeakersResponse.resolve(testAddedSpeakers);
             // Events
             $testScope.ctrl.speaker = testNewSpeaker;
             $testScope.addSpeaker();
@@ -259,11 +262,41 @@ describe("AdminController", function () {
 
         it("gets a new copy of the speakers list from the server and updates the local speakers list", function () {
             expect(adminDashDataService.getSpeakers).toHaveBeenCalledTimes(1);
-            expect($testScope.speakers).toEqual(testNewSpeakers);
+            expect($testScope.speakers).toEqual(testAddedSpeakers);
         });
 
         it("clears the local value of the 'speaker' input field", function () {
             expect($testScope.ctrl.speaker).toEqual("");
+        });
+    });
+
+    describe("removeSpeaker()", function () {
+
+        var deferredSpeakerResponse;
+
+        beforeEach(function () {
+            // Setup
+            deferredSpeakerResponse = $q.defer();
+            deferredSpeakerResponse.resolve();
+            adminDashDataService.removeSpeaker.and.returnValue(deferredSpeakerResponse.promise);
+            adminDashDataService.getSpeakers.and.returnValues(deferredGetSpeakersResponse.promise);
+            deferredGetSpeakersResponse.resolve(testRemovedSpeakers);
+            // Events
+            $testScope.removeSpeaker(testRemoveSpeaker);
+            $testScope.$apply();
+            $testScope.$apply();
+        });
+
+        it("calls the removeSpeaker function in the adminDashDataService with the value passed as an argument",
+            function () {
+                expect(adminDashDataService.removeSpeaker).toHaveBeenCalled();
+                expect(adminDashDataService.removeSpeaker.calls.allArgs()).toEqual([[testRemoveSpeaker]]);
+            }
+        );
+
+        it("gets a new copy of the speakers list from the server and updates the local speakers list", function () {
+            expect(adminDashDataService.getSpeakers).toHaveBeenCalledTimes(1);
+            expect($testScope.speakers).toEqual(testRemovedSpeakers);
         });
     });
 

--- a/spec/client/controllers/AdminController.spec.js
+++ b/spec/client/controllers/AdminController.spec.js
@@ -252,7 +252,6 @@ describe("AdminController", function () {
             $testScope.ctrl.speaker = testNewSpeaker;
             $testScope.addSpeaker();
             $testScope.$apply();
-            $testScope.$apply();
         });
 
         it("calls the addSpeaker function in the adminDashDataService with the value taken from the user", function () {

--- a/spec/client/controllers/AdminController.spec.js
+++ b/spec/client/controllers/AdminController.spec.js
@@ -284,7 +284,6 @@ describe("AdminController", function () {
             // Events
             $testScope.removeSpeaker(testRemoveSpeaker);
             $testScope.$apply();
-            $testScope.$apply();
         });
 
         it("calls the removeSpeaker function in the adminDashDataService with the value passed as an argument",


### PR DESCRIPTION
Adds the ability for the admin to view, add, and remove speakers from the dashboard menu. Uses placeholder (though possibly usable) functions in the admin data service, with no server-side implementation. Doesn't do anything practically right now as such, but has been unit-tested, and tested with mock data.
