### PR TITLE
Untrucate tweets

### DIFF
--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -18,6 +18,7 @@
         }
 
         function updateTweet(tweet) {
+            tweet.text = getUntruncatedText(tweet);
             tweet.text = addHashtag(tweet.text, tweet.entities.hashtags);
             tweet.text = addMention(tweet.text, tweet.entities.user_mentions);
             tweet.text = addUrl(tweet.text, tweet.entities.urls);
@@ -25,6 +26,14 @@
                 tweet.text = deleteMediaLink(tweet.text, tweet.entities.media);
             }
             return tweet.text;
+        }
+
+        function getUntruncatedText(tweet) {
+            if (tweet.retweeted_status) {
+                return "RT @" + tweet.retweeted_status.user.screen_name + ": " + tweet.retweeted_status.text;
+            } else {
+                return tweet.text;
+            }
         }
 
         function addHashtag(str, hashtags) {

--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -6,6 +6,7 @@
     function tweetTextManipulationService() {
         return {
             updateTweet: updateTweet,
+            getUntruncatedText: getUntruncatedText,
             addHashtag: addHashtag,
             addMention: addMention,
             addUrl: addUrl,

--- a/spec/client/services/tweetTextManipulationService.spec.js
+++ b/spec/client/services/tweetTextManipulationService.spec.js
@@ -8,11 +8,38 @@ describe("tweetTextManipulationService", function() {
         module("TwitterWallApp");
     });
 
+    var testTweet = {
+        text: "Test tweet 1",
+        entities: {
+            hashtags: [{
+                text: "hello"
+            }],
+            user_mentions: [{
+                screen_name: "bristech"
+            }],
+            urls: []
+        },
+        user: {
+            name: "Test user 1",
+            screen_name: "user1"
+        },
+        retweeted_status: {
+            text: "untruncated Test tweet 1",
+            user: {
+                name: "Original Tweeter",
+                screen_name: "original_tweeter"
+            }
+        }
+    };
+
     beforeEach(inject(function(_tweetTextManipulationService_) {
         tweetTextManipulationService = _tweetTextManipulationService_;
     }));
 
     describe("On string manipulation", function() {
+        it("gets the untruncated tweet text for retweets", function() {
+            expect(tweetTextManipulationService.getUntruncatedText(testTweet)).toEqual("RT @original_tweeter: untruncated Test tweet 1");
+        });
         it("adds special html tag for displaying hashtags inside tweets", function() {
             expect(tweetTextManipulationService.addHashtag("#hello world", [{
                 text: "hello"

--- a/spec/client/services/tweetTextManipulationService.spec.js
+++ b/spec/client/services/tweetTextManipulationService.spec.js
@@ -8,8 +8,8 @@ describe("tweetTextManipulationService", function() {
         module("TwitterWallApp");
     });
 
-    var testTweet = {
-        text: "Test tweet 1",
+    var truncatedTestTweet = {
+        text: "Test tweet 1...",
         entities: {
             hashtags: [{
                 text: "hello"
@@ -38,7 +38,8 @@ describe("tweetTextManipulationService", function() {
 
     describe("On string manipulation", function() {
         it("gets the untruncated tweet text for retweets", function() {
-            expect(tweetTextManipulationService.getUntruncatedText(testTweet)).toEqual("RT @original_tweeter: untruncated Test tweet 1");
+            expect(tweetTextManipulationService.getUntruncatedText(truncatedTestTweet))
+                .toEqual("RT @original_tweeter: untruncated Test tweet 1");
         });
         it("adds special html tag for displaying hashtags inside tweets", function() {
             expect(tweetTextManipulationService.addHashtag("#hello world", [{


### PR DESCRIPTION
Fixes bug where retweets would have their main text truncated with ellipses; now we just fetch the original text from the retweeted_status object.
