### PR TITLE
Fix tweet truncation and images

### DIFF
--- a/client/angular/controllers/MainController.js
+++ b/client/angular/controllers/MainController.js
@@ -118,7 +118,7 @@
                     var newTweets = [];
                     if (results.tweets.length > 0) {
                         results.tweets.forEach(function(tweet) {
-                            $sce.trustAsHtml(tweetTextManipulationService.updateTweet(tweet));
+                            tweet.displayText = $sce.trustAsHtml(tweetTextManipulationService.getDisplayText(tweet));
                         });
                         newTweets = $scope.setFlagsForTweets(results.tweets, vm.updates);
                     }

--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -5,7 +5,7 @@
 
     function tweetTextManipulationService() {
         return {
-            updateTweet: updateTweet,
+            getDisplayText: getDisplayText,
             getUntruncatedText: getUntruncatedText,
             addHashtag: addHashtag,
             addMention: addMention,
@@ -14,31 +14,34 @@
             deleteMediaLink: deleteMediaLink,
         };
 
-        function updateTweet(tweet) {
-            if (tweet.retweeted_status) {
-                tweet.text = getUntruncatedText(tweet);
-                tweet.entities = tweet.retweeted_status.entities;
-                tweet.truncated = tweet.retweeted_status.truncated;
-            }
-            tweet.text = addHashtag(tweet.text, tweet.entities.hashtags);
-            tweet.text = addMention(tweet.text, tweet.entities.user_mentions);
-            if (tweet.truncated) {
-                tweet.text = addUrls(tweet.text, tweet.entities.urls);
-            } else {
-                tweet.text = addDisplayUrls(tweet.text, tweet.entities.urls);
-            }
+        function getDisplayText(tweet) {
+            var displayText = getUntruncatedText(tweet);
+            var displayEntities = getEntities(tweet);
 
-            if (tweet.entities.media) {
-                tweet.text = deleteMediaLink(tweet.text, tweet.entities.media);
+            displayText = addHashtag(displayText, displayEntities.hashtags);
+            displayText = addMention(displayText, displayEntities.user_mentions);
+            displayText = addDisplayUrls(displayText, displayEntities.urls);
+
+            if (displayEntities.media) {
+                displayText = deleteMediaLink(displayText, displayEntities.media);
             }
-            return tweet.text;
+            
+            return displayText;
         }
 
         function getUntruncatedText(tweet) {
             if (tweet.retweeted_status) {
-                return "RT @" + tweet.retweeted_status.user.screen_name + ": " + tweet.retweeted_status.text;
+                return "RT @" + tweet.retweeted_status.user.screen_name + ": " + tweet.retweeted_status.full_text;
             } else {
-                return tweet.text;
+                return tweet.full_text;
+            }
+        }
+
+        function getEntities(tweet) {
+            if (tweet.retweeted_status) {
+                return tweet.retweeted_status.entities;
+            } else {
+                return tweet.entities;
             }
         }
 

--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -20,7 +20,7 @@
 
             displayText = addHashtag(displayText, displayEntities.hashtags);
             displayText = addMention(displayText, displayEntities.user_mentions);
-            if(tweet.retweeted_status){
+            if (tweet.retweeted_status) {
                 displayText = addUrls(displayText, displayEntities.urls);
             } else {
                 displayText = addDisplayUrls(displayText, displayEntities.urls);

--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -20,12 +20,16 @@
 
             displayText = addHashtag(displayText, displayEntities.hashtags);
             displayText = addMention(displayText, displayEntities.user_mentions);
-            displayText = addDisplayUrls(displayText, displayEntities.urls);
+            if(tweet.retweeted_status){
+                displayText = addUrls(displayText, displayEntities.urls);
+            } else {
+                displayText = addDisplayUrls(displayText, displayEntities.urls);
+            }
 
             if (displayEntities.media) {
                 displayText = deleteMediaLink(displayText, displayEntities.media);
             }
-            
+
             return displayText;
         }
 

--- a/client/templates/tweet.html
+++ b/client/templates/tweet.html
@@ -20,7 +20,7 @@
         </md-card-icon-actions>
     </md-card-header>
     <md-card-content layout="row" layout-padding layout-align="center center" style="flex:1">
-        <div ng-bind-html="tweet.text" ng-style="getSize(tweet.text)"></div>
+        <div ng-bind-html="tweet.displayText" ng-style="getSize(tweet.displayText)"></div>
         <img class="md-media-sm tweet-media" ng-if="tweet.entities.media[0].media_url_https!==undefined" ng-src="{{tweet.entities.media[0].media_url_https}}"/>
     </md-card-content>
     <md-card-footer>

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -185,10 +185,12 @@ module.exports = function(client, fs, eventConfigFile, mkdirp) {
 
     loadEventConfig(eventConfigFile, function() {
         var hashtagUpdateFn = tweetResourceGetter("search/tweets", {
-            q: hashtags.concat(mentions).join(" OR ")
+            q: hashtags.concat(mentions).join(" OR "),
+            tweet_mode: "extended"
         });
         var timelineUpdateFn = tweetResourceGetter("statuses/user_timeline", {
-            screen_name: officialUsers[0]
+            screen_name: officialUsers[0],
+            tweet_mode: "extended"
         });
         // Begins the chain of callbacks defined below
         rateCheckLoop();

--- a/spec/client/controllers/MainController.spec.js
+++ b/spec/client/controllers/MainController.spec.js
@@ -367,7 +367,7 @@ describe("MainController", function() {
             "updateInteractions",
         ]);
         tweetTextManipulationService = jasmine.createSpyObj("tweetTextManipulationService", [
-            "updateTweet",
+            "getDisplayText",
             "addHashtag",
             "addMention",
             "addUrl",
@@ -425,8 +425,8 @@ describe("MainController", function() {
             expect($testScope.tweets).toEqual(testTweets);
         });
         it("uses the tweet text manipulation service to format tweets for display", function() {
-            expect(tweetTextManipulationService.updateTweet).toHaveBeenCalledTimes(testTweets.length);
-            expect(tweetTextManipulationService.updateTweet.calls.allArgs()).toEqual(testTweets.map(function(tweet) {
+            expect(tweetTextManipulationService.getDisplayText).toHaveBeenCalledTimes(testTweets.length);
+            expect(tweetTextManipulationService.getDisplayText.calls.allArgs()).toEqual(testTweets.map(function(tweet) {
                 return [tweet];
             }));
         });

--- a/spec/client/controllers/MainController.spec.js
+++ b/spec/client/controllers/MainController.spec.js
@@ -48,6 +48,7 @@ describe("MainController", function() {
     var testBackfilledColumns;
 
     var testUri;
+    var testTweetDisplayText;
 
     function initValues() {
         testSuccessResponse = {
@@ -86,12 +87,12 @@ describe("MainController", function() {
 
         tweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
@@ -101,7 +102,7 @@ describe("MainController", function() {
 
         tweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
@@ -110,146 +111,157 @@ describe("MainController", function() {
 
         sizedTweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
             favorite_count: 0,
             retweet_count: 0,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         sizedTweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
             retweet_count: 0,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         deletedTweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
             favorite_count: 0,
             retweet_count: 0,
             deleted: true,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         favouritedTweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
             favorite_count: 100,
             retweet_count: 0,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         blockedTweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
             retweet_count: 0,
             blocked: true,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         interactedTweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
             retweet_count: 50,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         pinnedTweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
             favorite_count: 0,
             retweet_count: 0,
             pinned: true,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         speakerTweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
             retweet_count: 0,
             wallPriority: true,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
 
         retweetedTweet1 = {
             id_str: "1",
-            text: "RT Test tweet 1 #hello @bristech",
+            full_text: "RT Test tweet 1 #hello @bristech",
             entities: entities1,
             user: user1,
             retweeted_status: {
                 id_str: "5",
-                text: "Test tweet 1 #hello @bristech",
+                full_text: "Test tweet 1 #hello @bristech",
                 entities: entities1,
                 user: user2,
             },
             favorite_count: 0,
             retweet_count: 0,
             hide_retweet: true,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
+
         };
 
         retweetedTweet2 = {
             id_str: "2",
-            text: "Test tweet 2 www.google.com",
+            full_text: "Test tweet 2 www.google.com",
             entities: entities2,
             user: user2,
             favorite_count: 0,
             retweet_count: 0,
             hide_retweet: false,
+            displayText: jasmine.any(Object),
             displayHeightPx: jasmine.any(Number),
             displayWidthPx: jasmine.any(Number),
         };
@@ -342,6 +354,8 @@ describe("MainController", function() {
         ];
 
         testUri = "http://googleLoginPage.com";
+
+        testTweetDisplayText = "Tweet text displayed on screen";
     }
 
     initValues();
@@ -385,6 +399,7 @@ describe("MainController", function() {
         deferredUpdateInteractionsResponse = $q.defer();
         twitterWallDataService.getTweets.and.returnValue(deferredGetTweetsResponse.promise);
         twitterWallDataService.updateInteractions.and.returnValue(deferredUpdateInteractionsResponse.promise);
+        tweetTextManipulationService.getDisplayText.and.returnValue(testTweetDisplayText);
         columnAssignmentService.assignColumns.and.returnValue(testAssignedColumns);
         columnAssignmentService.sortColumns.and.returnValue(testSortedColumns);
         columnAssignmentService.backfillColumns.and.returnValue(testBackfilledColumns);

--- a/spec/client/services/tweetTextManipulationService.spec.js
+++ b/spec/client/services/tweetTextManipulationService.spec.js
@@ -9,7 +9,7 @@ describe("tweetTextManipulationService", function() {
     });
 
     var truncatedTestTweet = {
-        text: "Test tweet 1...",
+        full_text: "Test tweet 1...",
         entities: {
             hashtags: [{
                 text: "hello"
@@ -24,7 +24,7 @@ describe("tweetTextManipulationService", function() {
             screen_name: "user1"
         },
         retweeted_status: {
-            text: "untruncated Test tweet 1",
+            full_text: "untruncated Test tweet 1",
             user: {
                 name: "Original Tweeter",
                 screen_name: "original_tweeter"

--- a/spec/server/tweetSearch.spec.js
+++ b/spec/server/tweetSearch.spec.js
@@ -426,7 +426,8 @@ describe("tweetSearch", function() {
             var queries = getQueries("search/tweets");
             expect(queries.length).toEqual(1);
             expect(queries[0]).toEqual({
-                q: hashtags.concat(mentions).join(" OR ")
+                q: hashtags.concat(mentions).join(" OR "),
+                tweet_mode: "extended"
             });
         });
 
@@ -444,7 +445,8 @@ describe("tweetSearch", function() {
             var queries = getQueries("statuses/user_timeline");
             expect(queries.length).toEqual(1);
             expect(queries[0]).toEqual({
-                screen_name: officialUsers[0]
+                screen_name: officialUsers[0],
+                tweet_mode: "extended"
             });
         });
 


### PR DESCRIPTION
Uses the extended tweet mode query to avoid tweets ever getting truncated and to allow RT pictures to be shown, note : tweets now come in with a 'full_text' field rather than a 'text' field.

Also changed so the original 'full_text' field on the tweet isn't changed during parsing but instead we generate a new text field displayText to be shown on the page (Didn't really plan to do this, kind of just ended happening during debugging but does seems like a good idea)
