### PR TITLE
admin page doesn't get interaction updates

### DIFF
--- a/client/angular/controllers/MainController.js
+++ b/client/angular/controllers/MainController.js
@@ -84,7 +84,9 @@
             updateTweets();
             $interval(updateTweets, 500);
             $interval(redisplayTweets, 100);
-            $interval(updateInteractions, 5000);
+            if (!$scope.loggedIn) {
+                $interval(updateInteractions, 5000);
+            }
         }
 
         function adminViewEnabled() {


### PR DESCRIPTION
Don't bother asking for interaction updates from admin page, there could be hundreds of tweets on it and we can only ask for 100 at a time. We only get 180 requests in the window so save them for the main client.
