### PR TITLE
allow add/remove admins, use emails over subs

### DIFF
--- a/spec/server/authoriser.spec.js
+++ b/spec/server/authoriser.spec.js
@@ -43,13 +43,11 @@ describe("Authoriser", function() {
         fs = jasmine.createSpyObj("fs", [
             "readFile",
             "writeFile",
-            "asdf",
         ]);
         fs.readFile.and.callFake(function(file, encoding, callback) {
             callback(undefined, JSON.stringify(adminConfig));
         });
         fs.writeFile.and.callFake(function(file, contents, callback) {
-            console.log("WriteFile called");
             callback(undefined);
         });
 
@@ -173,7 +171,6 @@ describe("Authoriser", function() {
                 "emails": updatedEmails,
             };
             authoriser.addAdmin("charlie@gmail.com").then(function() {
-                console.log("Tests");
                 expect(fs.readFile).toHaveBeenCalled();
                 expect(fs.writeFile).toHaveBeenCalledWith(configFile, JSON.stringify(objToWrite), jasmine.any(Function));
             });


### PR DESCRIPTION
Added server-side functionality to add and remove admins and relevant tests. Rewrote old auth tests to use jasmine over sinon. Admin config file now uses email addresses instead of subs so this will need updated on prod as well as locally.
