### PR TITLE
Removed url truncation

### DIFF
--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -20,15 +20,14 @@
 
             displayText = addHashtag(displayText, displayEntities.hashtags);
             displayText = addMention(displayText, displayEntities.user_mentions);
-            if (tweet.retweeted_status) {
-                displayText = addUrls(displayText, displayEntities.urls);
-            } else {
-                displayText = addDisplayUrls(displayText, displayEntities.urls);
-            }
+
+            displayText = addDisplayUrls(displayText, displayEntities.urls);
 
             if (displayEntities.media) {
                 displayText = deleteMediaLink(displayText, displayEntities.media);
             }
+
+            displayText = displayText.replace(/https?\:\/\/(www.)?/i, "");
 
             return displayText;
         }
@@ -69,7 +68,13 @@
         function addDisplayUrls(str, urls) {
             urls.forEach(function(uri) {
                 var substr = uri.url;
-                str = str.split(substr).join("<b>" + uri.display_url + "</b>");
+                if (uri.expanded_url.length > 50) {
+                    //if the link in the tweet is very long then use the included shortened version
+                    str = str.split(substr).join("<b>" + uri.url + "</b>");
+                } else {
+                    str = str.split(substr).join("<b>" + uri.expanded_url + "</b>");
+                }
+
             });
             return str;
         }

--- a/client/angular/services/tweetTextManipulationService.js
+++ b/client/angular/services/tweetTextManipulationService.js
@@ -10,7 +10,6 @@
             addHashtag: addHashtag,
             addMention: addMention,
             addDisplayUrls: addDisplayUrls,
-            addUrls: addUrls,
             deleteMediaLink: deleteMediaLink,
         };
 
@@ -75,14 +74,6 @@
                     str = str.split(substr).join("<b>" + uri.expanded_url + "</b>");
                 }
 
-            });
-            return str;
-        }
-
-        function addUrls(str, urls) {
-            urls.forEach(function(uri) {
-                var substr = uri.url;
-                str = str.split(substr).join("<b>" + substr + "</b>");
             });
             return str;
         }

--- a/spec/client/services/tweetTextManipulationService.spec.js
+++ b/spec/client/services/tweetTextManipulationService.spec.js
@@ -54,13 +54,15 @@ describe("tweetTextManipulationService", function() {
         it("adds special html tag for displaying display urls inside tweets", function() {
             expect(tweetTextManipulationService.addDisplayUrls("www.hello world", [{
                 url: "www.hello",
-                display_url: "hell"
-            }])).toEqual("<b>hell</b> world");
+                display_url: "hello...",
+                expanded_url: "hellooooooo"
+            }])).toEqual("<b>hellooooooo</b> world");
         });
-        it("adds special html tag for displaying standard urls in tweets", function() {
+        it("uses shortened version of link if very long", function() {
             expect(tweetTextManipulationService.addUrls("www.hello world", [{
                 url: "www.hello",
-                display_url: "hell"
+                display_url: "hello...",
+                expanded_url: "hellooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             }])).toEqual("<b>www.hello</b> world");
         });
         it("delete media urls inside tweets", function() {

--- a/spec/client/services/tweetTextManipulationService.spec.js
+++ b/spec/client/services/tweetTextManipulationService.spec.js
@@ -59,7 +59,7 @@ describe("tweetTextManipulationService", function() {
             }])).toEqual("<b>hellooooooo</b> world");
         });
         it("uses shortened version of link if very long", function() {
-            expect(tweetTextManipulationService.addUrls("www.hello world", [{
+            expect(tweetTextManipulationService.addDisplayUrls("www.hello world", [{
                 url: "www.hello",
                 display_url: "hello...",
                 expanded_url: "hellooooooooooooooooooooooooooooooooooooooooooooooooooooo"


### PR DESCRIPTION
Stops urls at the ends of tweets being truncated with ellipses
If the full link is very long then uses the shortened version included in the tweet object
