### PR TITLE
visitor tweets in middle column

### DIFF
--- a/client/angular/controllers/MainController.js
+++ b/client/angular/controllers/MainController.js
@@ -68,10 +68,10 @@
                 return tweet.pinned === true && shouldBeDisplayed(tweet);
             }, pinnedOrdering, 1),
             new columnAssignmentService.ColumnData(5, function(tweet) {
-                return tweet.wallPriority === true && shouldBeDisplayed(tweet);
+                return tweet.wallPriority !== true && shouldBeDisplayed(tweet);
             }, chronologicalOrdering, 0),
             new columnAssignmentService.ColumnData(5 - $scope.secondLogo, function(tweet) {
-                return shouldBeDisplayed(tweet);
+                return tweet.wallPriority === true && shouldBeDisplayed(tweet);
             }, chronologicalOrdering, $scope.secondLogo),
         ];
 


### PR DESCRIPTION
Visitor tweets in middle column so most action happens in the middle of the screen. If there aren't enough pinned tweets, pinned column now fills from visitor tweets so wall is less dominated by bristech account.
