### PR TITLE
Persistent "approved tweets only" status

### DIFF
--- a/client/angular/controllers/AdminController.js
+++ b/client/angular/controllers/AdminController.js
@@ -169,7 +169,6 @@
 
         function getApprovedTweetsOnlyStatus() {
             adminDashDataService.getApprovedTweetsOnlyStatus().then(function(result) {
-                console.log("got approval status");
                 console.log(result.status);
                 $scope.ctrl.approvedTweetsOnly = result.status;
             }).catch(function(err) {

--- a/client/angular/controllers/AdminController.js
+++ b/client/angular/controllers/AdminController.js
@@ -118,6 +118,7 @@
                 });
                 $scope.loggedIn = true;
                 $scope.adminView = true;
+                $interval(getApprovedTweetsOnlyStatus, 500);
             }).catch(function() {
                 adminDashDataService.getAuthUri().then(function(uri) {
                     if ($routeParams.status === "unauthorised") {
@@ -163,6 +164,16 @@
                 $scope.admins = admins;
             }).catch(function(err) {
                 console.log("Could not get list of admins:" + err);
+            });
+        }
+
+        function getApprovedTweetsOnlyStatus() {
+            adminDashDataService.getApprovedTweetsOnlyStatus().then(function(result) {
+                console.log("got approval status");
+                console.log(result.status);
+                $scope.ctrl.approvedTweetsOnly = result.status;
+            }).catch(function(err) {
+                console.log("Could not get current approved tweets status:" + err);
             });
         }
     }

--- a/client/angular/controllers/AdminController.js
+++ b/client/angular/controllers/AdminController.js
@@ -118,6 +118,7 @@
                 });
                 $scope.loggedIn = true;
                 $scope.adminView = true;
+                getApprovedTweetsOnlyStatus();
                 $interval(getApprovedTweetsOnlyStatus, 500);
             }).catch(function() {
                 adminDashDataService.getAuthUri().then(function(uri) {
@@ -169,7 +170,6 @@
 
         function getApprovedTweetsOnlyStatus() {
             adminDashDataService.getApprovedTweetsOnlyStatus().then(function(result) {
-                console.log(result.status);
                 $scope.ctrl.approvedTweetsOnly = result.status;
             }).catch(function(err) {
                 console.log("Could not get current approved tweets status:" + err);

--- a/client/angular/services/adminDashDataService.js
+++ b/client/angular/services/adminDashDataService.js
@@ -24,7 +24,8 @@
             getAdmins: getAdmins,
             addAdmin: addAdmin,
             removeAdmin: removeAdmin,
-            setApprovedTweetsOnlyStatus: setApprovedTweetsOnlyStatus
+            setApprovedTweetsOnlyStatus: setApprovedTweetsOnlyStatus,
+            getApprovedTweetsOnlyStatus: getApprovedTweetsOnlyStatus
         };
 
         function deletePictureFromTweet(id) {
@@ -163,6 +164,12 @@
         function setApprovedTweetsOnlyStatus(status) {
             return $http.post("/admin/tweets/approvedTweetsOnlyStatus", {
                 status: status
+            });
+        }
+
+        function getApprovedTweetsOnlyStatus() {
+            return $http.get("/admin/tweets/approvedTweetsOnlyStatus").then(function(result) {
+                return result.data;
             });
         }
     }

--- a/server/server.js
+++ b/server/server.js
@@ -159,12 +159,8 @@ module.exports = function(port, tweetSearcher, googleAuthoriser) {
     });
 
     app.get("/admin/tweets/approvedTweetsOnlyStatus", function(req, res) {
-        try {
-            var status = tweetSearcher.getApprovalMode();
-            res.json(status);
-        } catch (err) {
-            res.sendStatus(404);
-        }
+        var status = tweetSearcher.getApprovalMode();
+        res.json(status);
     });
 
     app.get("/admin/administrators", function(req, res) {

--- a/server/server.js
+++ b/server/server.js
@@ -158,6 +158,15 @@ module.exports = function(port, tweetSearcher, googleAuthoriser) {
         }
     });
 
+    app.get("/admin/tweets/approvedTweetsOnlyStatus", function(req, res) {
+        try {
+            var status = tweetSearcher.getApprovalMode();
+            res.json(status);
+        } catch (err) {
+            res.sendStatus(404);
+        }
+    });
+
     app.get("/admin/administrators", function(req, res) {
         googleAuthoriser.getAdmins()
             .then(function(admins) {

--- a/server/tweetSearch.js
+++ b/server/tweetSearch.js
@@ -57,6 +57,12 @@ module.exports = function(client, fs, eventConfigFile, mkdirp) {
         inApprovalMode = approveTweets;
     }
 
+    function getApprovalMode() {
+        return {
+            status: inApprovalMode
+        };
+    }
+
     function updateInteractions(visibleTweets, callback) {
         var interactionUpdates = {
             favourites: [],
@@ -266,7 +272,8 @@ module.exports = function(client, fs, eventConfigFile, mkdirp) {
         displayBlockedTweet: displayBlockedTweet,
         setRetweetDisplayStatus: setRetweetDisplayStatus,
         updateInteractions: updateInteractions,
-        setApprovalMode: setApprovalMode
+        setApprovalMode: setApprovalMode,
+        getApprovalMode: getApprovalMode
     };
 
     function checkRateLimitSafety(callback) {

--- a/spec/client/controllers/AdminController.spec.js
+++ b/spec/client/controllers/AdminController.spec.js
@@ -12,6 +12,7 @@ describe("AdminController", function() {
     var deferredGetSpeakersResponse;
     var deferredBlockedUsersResponse;
     var deferredGetAdminsResponse;
+    var deferredGetApprovedTweetsStatusResponse;
 
     var testSuccessResponse;
     var user1;
@@ -87,7 +88,8 @@ describe("AdminController", function() {
             "displayBlockedTweet",
             "getAdmins",
             "addAdmin",
-            "removeAdmin"
+            "removeAdmin",
+            "getApprovedTweetsOnlyStatus"
         ]);
 
         deferredAuthenticateResponse = $q.defer();
@@ -96,6 +98,7 @@ describe("AdminController", function() {
         deferredGetSpeakersResponse = $q.defer();
         deferredBlockedUsersResponse = $q.defer();
         deferredGetAdminsResponse = $q.defer();
+        deferredGetApprovedTweetsStatusResponse = $q.defer();
 
         adminDashDataService.authenticate.and.returnValue(deferredAuthenticateResponse.promise);
         adminDashDataService.getAuthUri.and.returnValue(deferredGetAuthUriResponse.promise);
@@ -105,6 +108,7 @@ describe("AdminController", function() {
         adminDashDataService.addBlockedUser.and.returnValue(deferredBlockedUsersResponse.promise);
         adminDashDataService.removeBlockedUser.and.returnValue(deferredBlockedUsersResponse.promise);
         adminDashDataService.getAdmins.and.returnValue(deferredGetAdminsResponse.promise);
+        adminDashDataService.getApprovedTweetsOnlyStatus.and.returnValue(deferredGetApprovedTweetsStatusResponse.promise);
 
         AdminController = _$controller_("AdminController", {
             $scope: $testScope,
@@ -130,6 +134,13 @@ describe("AdminController", function() {
                 $testScope.$apply();
                 expect(adminDashDataService.getSpeakers).toHaveBeenCalled();
                 expect($testScope.speakers).toEqual(testSpeakers);
+            });
+            it("gets the current status of approved-tweets-only", function() {
+                deferredGetApprovedTweetsStatusResponse.resolve({
+                    status: true
+                });
+                $testScope.$apply();
+                expect($testScope.ctrl.approvedTweetsOnly).toEqual(true);
             });
         });
         describe("when not already authenticated", function() {

--- a/spec/client/services/adminDashDataService.spec.js
+++ b/spec/client/services/adminDashDataService.spec.js
@@ -53,6 +53,11 @@ describe("adminDashDataService", function() {
             .when("POST", "/admin/tweets/approvedTweetsOnlyStatus")
             .respond(200, "");
         $httpMock
+            .when("GET", "/admin/tweets/approvedTweetsOnlyStatus")
+            .respond(200, {
+                status: true
+            });
+        $httpMock
             .when("GET", "/admin/administrators")
             .respond(adminConfig);
         $httpMock
@@ -390,6 +395,36 @@ describe("adminDashDataService", function() {
                 var failed = jasmine.createSpy("failed");
                 $httpMock.expectPOST("/admin/tweets/approvedTweetsOnlyStatus").respond(500, "");
                 adminDashDataService.setApprovedTweetsOnlyStatus(true).catch(failed).then(function(result) {
+                    expect(failed.calls.any()).toEqual(true);
+                    expect(failed.calls.argsFor(0)[0].status).toEqual(500);
+                    done();
+                });
+                $httpMock.flush();
+            }
+        );
+    });
+
+    describe("getApprovedTweetsOnlyStatus", function() {
+        it("returns a promise which resolves with a status object",
+            function(done) {
+                var failed = jasmine.createSpy("failed");
+                $httpMock.expectGET("/admin/tweets/approvedTweetsOnlyStatus");
+                adminDashDataService.getApprovedTweetsOnlyStatus().catch(failed).then(function(result) {
+                    expect(failed.calls.any()).toEqual(false);
+                    expect(result).toEqual({
+                        status: true
+                    });
+                    done();
+                });
+                $httpMock.flush();
+            }
+        );
+
+        it("returns a promise which rejects when getApprovedTweetsOnlyStatus() is called and the server returns an error code",
+            function(done) {
+                var failed = jasmine.createSpy("failed");
+                $httpMock.expectGET("/admin/tweets/approvedTweetsOnlyStatus").respond(500, "");
+                adminDashDataService.getApprovedTweetsOnlyStatus().catch(failed).then(function(result) {
                     expect(failed.calls.any()).toEqual(true);
                     expect(failed.calls.argsFor(0)[0].status).toEqual(500);
                     done();

--- a/spec/server/admin.spec.js
+++ b/spec/server/admin.spec.js
@@ -33,7 +33,8 @@ describe("Admin", function() {
             "setRetweetDisplayStatus",
             "setTweetImageHidden",
             "updateInteractions",
-            "setApprovalMode"
+            "setApprovalMode",
+            "getApprovalMode"
         ]);
         tweetSearcher.updateInteractions.and.callFake(function(tweets, callback) {
             callback(null, "interactions");
@@ -568,6 +569,31 @@ describe("Admin", function() {
                     }, function(error, response, body) {
                         expect(response.statusCode).toEqual(200);
                         expect(tweetSearcher.getSpeakers).toHaveBeenCalled();
+                        done();
+                    });
+                });
+            });
+        });
+
+        describe("GET /admin/tweets/approvedTweetsOnlyStatus", function() {
+            it("responds with 401 if not logged in", function(done) {
+                request.get(baseUrl + "/admin/tweets/approvedTweetsOnlyStatus", function(error, response, body) {
+                    expect(response.statusCode).toEqual(401);
+                    done();
+                });
+            });
+
+            it("responds with 200 if logged in", function(done) {
+                authenticateUser(testToken, function() {
+                    request.get({
+                        url: baseUrl + "/admin/tweets/approvedTweetsOnlyStatus",
+                        jar: cookieJar,
+                        headers: {
+                            "Content-type": "application/json"
+                        }
+                    }, function(error, response, body) {
+                        expect(response.statusCode).toEqual(200);
+                        expect(tweetSearcher.getApprovalMode).toHaveBeenCalled();
                         done();
                     });
                 });


### PR DESCRIPTION
Polls an GET endpoint for making sure the approved tweets only checkbox reflects the state on the server
