### PR TITLE
centre retweet icon

### DIFF
--- a/client/css/tweet.scss
+++ b/client/css/tweet.scss
@@ -116,7 +116,8 @@ b {
   color: #E81C4F; }
 
 .retweet-icon {
-  color: #19CF86; }
+  color: #19CF86;
+  display: block; }
 
 .pinned-button-selected {
   color: #FFC400; }


### PR DESCRIPTION
div containing RT icon is now same height as RT icon so the rotation animation is around the centre of the circle
