### PR TITLE
column indicator bars centred on content

### DIFF
--- a/client/css/adminMenu.scss
+++ b/client/css/adminMenu.scss
@@ -24,12 +24,18 @@
 	display: flex; 
 	flex-direction: row; 
 	justify-content: space-around;
+	overflow-y: scroll;
 }
+
+.columns-header::-webkit-scrollbar {
+	visibility:hidden;
+} 
 
 .column-indicator {
 	border-bottom: 2px solid rgb(255,64,129); 
 	color: white; 
-	width: 30%;
+	margin-left: 12px;
+	margin-right: 12px;
 }
 
 .column-indicator-writing {

--- a/client/templates/clientTweetWall.html
+++ b/client/templates/clientTweetWall.html
@@ -1,13 +1,13 @@
 <style> {{tweetSizeStyles}} </style>
 <md-content layout="column" class="container" ng-style="{'overflow-y' : (loggedIn ? 'auto' : 'hidden')}">
   <div ng-if="adminView" class="columns-header">
-    <div class="column-indicator">
+    <div flex class="column-indicator">
       <p class="column-indicator-writing">Pinned</p>
     </div>
-    <div class="column-indicator">
+    <div flex class="column-indicator">
       <p class="column-indicator-writing">Visitors</p>
     </div>
-    <div class="column-indicator">
+    <div flex class="column-indicator">
       <p class="column-indicator-writing">Speakers</p>
     </div>
   </div>


### PR DESCRIPTION
A secret scrollbar keeps the column headers centred over the columns in the admin view.
